### PR TITLE
Fix some typos in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,7 +243,7 @@ The rest happens automatically: a new ``rq`` subcommand will be added to the
 ``flask`` command that wraps RQ's own ``rq`` CLI tool using the Flask
 configuration values.
 
-Please call ``flask rq --help`` for more infomation, assuming
+Please call ``flask rq --help`` for more information, assuming
 you've set the ``FLASK_APP`` environment variable to the Flask app path.
 
 You can install the dependencies for this using this shortcut:
@@ -274,7 +274,7 @@ command manager with the main script manager. For example:
 That adds a ``rq`` subcommand to your management script and wraps RQ's own
 ``rq`` CLI tools automatically using the Flask configuration values.
 
-Please call ``python manage.py rq --help`` for more infomation, assuming
+Please call ``python manage.py rq --help`` for more information, assuming
 your management script is called ``manage.py``.
 
 You can also install the dependencies for this using this shortcut:

--- a/src/flask_rq2/app.py
+++ b/src/flask_rq2/app.py
@@ -240,10 +240,10 @@ class RQ(object):
         :type timeout: int
         :param result_ttl: Time to persist the job results in Redis,
                            in seconds.
-        :type timeout: int
+        :type result_ttl: int
         :param ttl: The maximum queued time of the job before it'll be
                     cancelled.
-        :type timeout: int
+        :type ttl: int
         """
         if callable(func_or_queue):
             func = func_or_queue

--- a/src/flask_rq2/helpers.py
+++ b/src/flask_rq2/helpers.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 class JobFunctions(object):
     """
-    Some helper functions that are addded to a function decorated
+    Some helper functions that are added to a function decorated
     with a :meth:`~flask_rq2.app.RQ.job` decorator.
     """
     #: the methods to add to jobs automatically

--- a/src/flask_rq2/script.py
+++ b/src/flask_rq2/script.py
@@ -249,7 +249,7 @@ class RQManager(Manager):
 
     Then you'll be able to call ``python manage.py rq info`` etc.
 
-    Please call ``python manage.py rq --help`` for more infomation.
+    Please call ``python manage.py rq --help`` for more information.
     """
     def __init__(self, rq, *args, **kwargs):
         self.rq = rq

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -37,13 +37,13 @@ def test_job_custom_queue(rq):
 def test_job_with_params(rq):
 
     @rq.job(timeout=1337, result_ttl=1984, ttl=666)
-    def substract(x, y):
+    def subtract(x, y):
         return x - y
 
-    assert substract.helper.queue_name == rq.default_queue
-    assert substract.helper.timeout == 1337
-    assert substract.helper.result_ttl == 1984
-    assert substract.helper.ttl == 666
+    assert subtract.helper.queue_name == rq.default_queue
+    assert subtract.helper.timeout == 1337
+    assert subtract.helper.result_ttl == 1984
+    assert subtract.helper.ttl == 666
 
 
 def add(x, y):


### PR DESCRIPTION
Hi,

I found a couple typos in the documentation, and in one function name used in tests. Let me know what you think.

Thanks for this library!