### PR TITLE
helpers.py: set default_timeout in app factory

### DIFF
--- a/src/flask_rq2/app.py
+++ b/src/flask_rq2/app.py
@@ -258,7 +258,7 @@ class RQ(object):
                 rq=self,
                 wrapped=wrapped,
                 queue_name=queue_name or self.default_queue,
-                timeout=timeout or self.default_timeout,
+                timeout=timeout,
                 result_ttl=result_ttl or DEFAULT_RESULT_TTL,
                 ttl=ttl,
             )

--- a/src/flask_rq2/helpers.py
+++ b/src/flask_rq2/helpers.py
@@ -46,7 +46,7 @@ class JobFunctions(object):
             self.wrapped,
             args=args,
             kwargs=kwargs,
-            timeout=self.timeout,
+            timeout=self.timeout or self.rq.default_timeout,
             result_ttl=self.result_ttl,
             ttl=self.ttl,
             description=description,


### PR DESCRIPTION
Fixes #3

Be able to define the default timeout
in the application factory using the
default_timeout attribute.
