### PR TITLE
Make rq worker command understands --sentry-dsn argument

### DIFF
--- a/src/flask_rq2/cli.py
+++ b/src/flask_rq2/cli.py
@@ -107,6 +107,7 @@ def info(rq, ctx, path, interval, raw, only_queues, only_workers, by_queue,
               help='Default worker timeout to be used')
 @click.option('--verbose', '-v', is_flag=True, help='Show more output')
 @click.option('--quiet', '-q', is_flag=True, help='Show less output')
+@click.option('--sentry-dsn', default=None, help='Sentry DSN address')
 @click.option('--exception-handler', help='Exception handler(s) to use',
               multiple=True)
 @click.option('--pid',
@@ -115,7 +116,7 @@ def info(rq, ctx, path, interval, raw, only_queues, only_workers, by_queue,
 @click.argument('queues', nargs=-1)
 @rq_command()
 def worker(rq, ctx, burst, name, path, results_ttl, worker_ttl,
-           verbose, quiet, exception_handler, pid, queues):
+           verbose, quiet, sentry_dsn, exception_handler, pid, queues):
     "Starts an RQ worker."
     ctx.invoke(
         rq_cli.worker,
@@ -131,7 +132,7 @@ def worker(rq, ctx, burst, name, path, results_ttl, worker_ttl,
         worker_ttl=worker_ttl,
         verbose=verbose,
         quiet=quiet,
-        sentry_dsn=None,
+        sentry_dsn=sentry_dsn,
         exception_handler=exception_handler or rq._exception_handlers,
         pid=pid,
         queues=queues or rq.queues,

--- a/src/flask_rq2/script.py
+++ b/src/flask_rq2/script.py
@@ -148,6 +148,7 @@ class WorkerCommand(RQCommand):
         Option('--verbose', '-v', action='store_true',
                help='Show more output'),
         Option('--quiet', '-q', action='store_true', help='Show less output'),
+        Option('--sentry-dsn', type=str, help='Sentry DSN address'),
         Option('--exception-handler', type=list,
                help='Exception handler(s) to use', action='append'),
         Option('--pid', metavar='FILE',
@@ -159,7 +160,7 @@ class WorkerCommand(RQCommand):
     )
 
     def run(self, burst, name, path, results_ttl, worker_ttl, verbose,
-            quiet, exception_handler, pid, queues):
+            quiet, sentry_dsn, exception_handler, pid, queues):
         cli.worker.callback(
             url=self.rq.url,
             config=None,
@@ -173,7 +174,7 @@ class WorkerCommand(RQCommand):
             worker_ttl=worker_ttl,
             verbose=verbose,
             quiet=quiet,
-            sentry_dsn=None,
+            sentry_dsn=sentry_dsn,
             exception_handler=exception_handler or self.rq._exception_handlers,
             pid=pid,
             queues=queues or self.rq.queues,


### PR DESCRIPTION
Hi!
First of all, thank you for a great library.
This PR makes possible to pass `--sentry-dsn` argument to `rq worker` command, and after it `rq` starts sent its exceptions to sentry. 
