### PR TITLE
Adds 'rq>0.7' version support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup_params = dict(
     setup_requires=[] + pytest_runner,
     install_requires=[
         'Flask>=0.10',
-        'rq>=0.6.0,<0.7.0',
+        'rq>=0.6.0',
         'rq-scheduler>=0.6.1',
     ],
     extras_require=extras_require,

--- a/src/flask_rq2/cli.py
+++ b/src/flask_rq2/cli.py
@@ -9,11 +9,11 @@
 import operator
 import os
 from functools import update_wrapper
-import click
 
-from flask_rq2.helpers import is_rq_version_greater_than
+import click
 from rq.cli import cli as rq_cli
 
+from flask_rq2.helpers import is_rq_version_greater_than
 
 try:
     from flask.cli import AppGroup, ScriptInfo

--- a/src/flask_rq2/cli.py
+++ b/src/flask_rq2/cli.py
@@ -10,7 +10,10 @@ import operator
 import os
 from functools import update_wrapper
 import click
+
+from flask_rq2.helpers import is_rq_version_greater_than
 from rq.cli import cli as rq_cli
+
 
 try:
     from flask.cli import AppGroup, ScriptInfo
@@ -114,12 +117,14 @@ def info(rq, ctx, path, interval, raw, only_queues, only_workers, by_queue,
               help='Write the process ID number to a file at '
                    'the specified path')
 @click.argument('queues', nargs=-1)
+@click.option('--connection-class', default='redis.StrictRedis',
+              help='Redis client class to use')
 @rq_command()
 def worker(rq, ctx, burst, name, path, results_ttl, worker_ttl,
-           verbose, quiet, sentry_dsn, exception_handler, pid, queues):
+           verbose, quiet, sentry_dsn, exception_handler,
+           pid, queues, connection_class):
     "Starts an RQ worker."
-    ctx.invoke(
-        rq_cli.worker,
+    kwargs = dict(
         url=rq.url,
         config=None,
         burst=burst,
@@ -136,6 +141,15 @@ def worker(rq, ctx, burst, name, path, results_ttl, worker_ttl,
         exception_handler=exception_handler or rq._exception_handlers,
         pid=pid,
         queues=queues or rq.queues,
+    )
+
+    if is_rq_version_greater_than('0.7.0'):  # pragma: no cover
+        # Not all rq versions have this param.
+        kwargs.update(connection_class=connection_class)
+
+    ctx.invoke(
+        rq_cli.worker,
+        **kwargs
     )
 
 

--- a/src/flask_rq2/helpers.py
+++ b/src/flask_rq2/helpers.py
@@ -4,6 +4,9 @@
     ~~~~~~~~~~~~~~~~~
 """
 from datetime import datetime, timedelta
+from packaging.version import parse
+
+import rq
 
 
 class JobFunctions(object):
@@ -121,3 +124,15 @@ class JobFunctions(object):
             queue_name=self.queue_name,
             id='cron-%s' % name,
         )
+
+
+def is_rq_version_greater_than(version):
+    """
+    A function to check rq version. It is required in
+    several places, to check API incompatibilities.
+
+    :param version: Version number to check,
+                    could be strict or loose.
+    :type version: str
+    """
+    return parse(rq.__version__) > parse(version)

--- a/src/flask_rq2/script.py
+++ b/src/flask_rq2/script.py
@@ -12,9 +12,9 @@ import operator
 import os
 import re
 
-from rq.cli import cli
-
+from flask_rq2.helpers import is_rq_version_greater_than
 from flask_script import Command, Manager, Option
+from rq.cli import cli
 
 try:
     from rq_scheduler import Scheduler
@@ -156,12 +156,16 @@ class WorkerCommand(RQCommand):
                     'to a file at the specified path'),
         Option('queues', nargs='*', metavar='QUEUE',
                help='Queues to work with, defaults to the ones specified '
-                    'in the Flask app config')
+                    'in the Flask app config'),
+        Option('--connection-class',
+               default='redis.StrictRedis',
+               help='Redis client class to use'),
     )
 
     def run(self, burst, name, path, results_ttl, worker_ttl, verbose,
-            quiet, sentry_dsn, exception_handler, pid, queues):
-        cli.worker.callback(
+            quiet, sentry_dsn, exception_handler,
+            pid, queues, connection_class):
+        kwargs = dict(
             url=self.rq.url,
             config=None,
             burst=burst,
@@ -179,6 +183,12 @@ class WorkerCommand(RQCommand):
             pid=pid,
             queues=queues or self.rq.queues,
         )
+
+        if is_rq_version_greater_than('0.7.0'):  # pragma: no cover
+            # Not all rq versions have this param.
+            kwargs.update(connection_class=connection_class)
+
+        cli.worker.callback(**kwargs)
 
 
 @RQCommand.register()

--- a/src/flask_rq2/script.py
+++ b/src/flask_rq2/script.py
@@ -12,9 +12,10 @@ import operator
 import os
 import re
 
+from rq.cli import cli
+
 from flask_rq2.helpers import is_rq_version_greater_than
 from flask_script import Command, Manager, Option
-from rq.cli import cli
 
 try:
     from rq_scheduler import Scheduler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import os
 
+from click.testing import CliRunner
+
 import pytest
 
-from click.testing import CliRunner
 from flask_rq2 import RQ
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 import os
-from click.testing import CliRunner
 
 import pytest
 
+from click.testing import CliRunner
 from flask_rq2 import RQ
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,14 +2,13 @@
 import types
 from importlib import import_module
 
+import pytest
+from flask_rq2 import RQ
 from redis import Redis
 from rq.job import Job
 from rq.queue import Queue
 from rq.worker import Worker
 from rq_scheduler import Scheduler
-
-import pytest
-from flask_rq2 import RQ
 
 
 def exception_handler(*args, **kwargs):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,13 +2,14 @@
 import types
 from importlib import import_module
 
-import pytest
-from flask_rq2 import RQ
 from redis import Redis
 from rq.job import Job
 from rq.queue import Queue
 from rq.worker import Worker
 from rq_scheduler import Scheduler
+
+import pytest
+from flask_rq2 import RQ
 
 
 def exception_handler(*args, **kwargs):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,9 +1,9 @@
 import logging
 import sys
 
-import pytest
-
 from flask import current_app
+
+import pytest
 from flask_rq2 import app as flask_rq2_app
 from flask_rq2 import script as flask_rq2_script
 from flask_rq2 import RQ

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,9 +1,9 @@
 import logging
 import sys
-from flask import current_app
 
 import pytest
 
+from flask import current_app
 from flask_rq2 import app as flask_rq2_app
 from flask_rq2 import script as flask_rq2_script
 from flask_rq2 import RQ

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,10 @@ deps =
     coverage
     lowest: Flask==0.10
     lowest: click==2.0
+    lowest: rq>=0.6,<0.7
     latest: Flask
     latest: click
+    latest: rq
     devel: git+https://github.com/pallets/flask
     devel: git+https://github.com/pallets/click
 commands =


### PR DESCRIPTION
Duplicate of https://github.com/jezdez/Flask-RQ2/pull/17 but with fixed isort.

I suggest adding .isort.cfg because of difference between running tests with and without virtualenv (https://github.com/timothycrosley/isort/issues/498)
