### PR TITLE
Added timeout to cron

### DIFF
--- a/src/flask_rq2/helpers.py
+++ b/src/flask_rq2/helpers.py
@@ -120,4 +120,5 @@ class JobFunctions(object):
             repeat=repeat,
             queue_name=self.queue_name,
             id='cron-%s' % name,
+            timeout=self.timeout
         )


### PR DESCRIPTION
RQ Scheduler supports a timeout value for cron jobs. I've added the ability to pass this timeout value via Flask-RQ2